### PR TITLE
added sitemap build for docsearch; fixed JSON lint issue

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -19,6 +19,9 @@
     }
   ],
   "build": {
+    "sitemap": {
+      "baseUrl": "https://dnndocs.com/"
+    },
     "content": [
       {
         "files": ["api/**.yml", "api/index.md"]
@@ -54,7 +57,6 @@
     "noLangKeyword": false,
     "keepFileLink": false,
     "cleanupCacheHistory": false,
-    "disableGitFeatures": false
-    } 
+    "disableGitFeatures": false 
   }
 }


### PR DESCRIPTION
Resolves #131. Docsearch config PR needs to be submitted to pickup the sitemap URL.