### PR TITLE
Fix configure sitemap table and callout

### DIFF
--- a/content/administrators/configuring-your-site/configure-check-for-new-version/index.md
+++ b/content/administrators/configuring-your-site/configure-check-for-new-version/index.md
@@ -13,7 +13,8 @@ related-topics: update-site-info,assign-key-pages,add-metadata-to-pages,configur
 
 You can choose to be automatically notified if DNN releases a newer version.
 
-Note: This setting only triggers a notification. It does not perform the upgrade.
+ > [!Note]
+ > This setting only triggers a notification. It does not perform the upgrade.
 
 ## Prerequisites
 

--- a/content/administrators/setup/upgrade-evoq/index.md
+++ b/content/administrators/setup/upgrade-evoq/index.md
@@ -28,7 +28,8 @@ In the test environment,
 
 Even if your site is a web farm, only one server is required for the test environment. To avoid conflicts in a web farm, the upgrade is performed only with a single server enabled.
 
- <div class="blue-callout"><strong>Tip:</strong> Take notes about the steps you perform and the configuration settings you use, so you can repeat them exactly when you upgrade your live site.
+ > [!Tip]
+ > Take notes about the steps you perform and the configuration settings you use, so you can repeat them exactly when you upgrade your live site.
 
 After you confirm that the upgraded test site works properly, create another backup of the live database and the live file system to include changes made to the live site during your test.
 
@@ -55,7 +56,8 @@ If you decide to simply use the upgraded test site as your new live site, you ca
     1.  Go to [the Downloads section of dnnsoftware.com](https://www.dnnsoftware.com/services/customer-support/success-network/software-downloads).
     2.  Click the Upgrade button for your Evoq product.
 
-         <div class="blue-callout"><strong>Note:</strong> If Windows requires you to unblock the zip file after download, find the file in Windows Explorer, right-click and select Properties. Then click Unblock, if the option exists.</div>
+         > [!Note]
+         > If Windows requires you to unblock the zip file after download, find the file in Windows Explorer, right-click and select Properties. Then click Unblock, if the option exists.
 
     3.  Extract the contents of the zip file to the root folder of the test website, while preserving the folder structure.
 
@@ -63,7 +65,8 @@ If you decide to simply use the upgraded test site as your new live site, you ca
 
 7.  Go to https://localhost/install/install.aspx?mode=upgrade to start the installation.
 
-     <div class="blue-callout">Note: If using a portal alias that was added to the machine's hosts file, use that fully-qualified domain name, instead of localhost.</div>
+     > [!Note]
+     > If using a portal alias that was added to the machine's hosts file, use that fully-qualified domain name, instead of localhost.
 
     If you encounter ANY error:
 

--- a/content/administrators/sitemaps/configure-sitemap/index.md
+++ b/content/administrators/sitemaps/configure-sitemap/index.md
@@ -37,11 +37,14 @@ related-topics: submit-site-Google-search,module-sitemap
     |---|---|
     |<strong>Sitemap URL</strong>|The location of the sitemap.|
     |<strong>Exclude URLs With a Priority Lower Than</strong>|The lowest priority to include in the sitemap.|
-    |<strong>Include Hidden Pages</strong>If enabled (On), pages that are not visible in the menu are also included in the sitemap.|
-    |<strong>Days to Cache Sitemap For</strong>|The number of days before the sitemap is regenerated. If set to Disable Caching, the sitemap is regenerated, only when requested.Tip: If you have a large site (i.e., at least 50,000 URLs), cache the sitemap for at least one day to help improve your site's performance.|
+    |<strong>Include Hidden Pages</strong>|If enabled (On), pages that are not visible in the menu are also included in the sitemap.|
+    |<strong>Days to Cache Sitemap For</strong>|The number of days before the sitemap is regenerated. If set to Disable Caching, the sitemap is regenerated, only when requested.|
     |<strong>Clear Cache</strong>|Click/Tap to delete all cached sitemaps. A new sitemap is generated at the next request.|
     |<strong>Minimum Priority for Pages</strong>|If Use page level based priorities? is checked, the lowest priority to assign to pages. Example, if the minimum priority is 0.7,<ul><li>Root/Level 1 gets a priority of 1.0.</li><li>Level 2 gets a priority of 0.9.</li><li>Level 3 gets a priority of 0.8.</li><li>Level 4 and all lower levels get a priority of 0.7.</li></ul>|
     |<strong>Use Page Level Based Priorities</strong>|If enabled (On), the priority for each page is computed based on its hierarchy level. Top level pages are assigned a priority of 1.0, and lower levels are 0.1 less than the next higher level (i.e., the second level pages are assigned a priority of 0.9; the third level, 0.8).|
+
+    > [!Tip] 
+    > If you have a large site (i.e., at least 50,000 URLs), cache the sitemap for at least one day to help improve your site's performance.
     
 4.  Enable and configure the sitemap providers you want to use.
     

--- a/index.md
+++ b/index.md
@@ -13,16 +13,16 @@
                             <h4 class="hlead">Get Started</h4>
                             <ul>
                                 <li><a href="/content/administrators/dnn-overview/index.html">What is DNN?</a></li>
-                                <li><a>Install/Upgrade</a></li>
-                                <li><a>Version History</a></li>
+                                <li><a href="https://dnndocs.com/content/administrators/setup/set-up-dnn-folder/index.html">Install/Upgrade</a></li>
+                                <li><a href="https://dnndocs.com/content/administrators/product-versions/index.html">Version History</a></li>
                             </ul>
                         </div>
                         <div class="col-sm-4">
                             <h4 class="hlead">Extend DNN</h4>
                             <ul>
-                                <li><a>Creating Themes</a></li>
-                                <li><a>Creating Extensions</a></li>
-                                <li><a>DNN API</a></li>
+                                <li><a href="https://dnndocs.com/content/designers/creating-themes/designers-creating-themes-overview/index.html">Creating Themes</a></li>
+                                <li><a href="https://dnndocs.com/content/developers/extensions/developers-extensions-overview/index.html">Creating Extensions</a></li>
+                                <li><a href="https://dnndocs.com/api/">DNN API</a></li>
                             </ul>
                         </div>
                         <div class="col-sm-4">
@@ -62,8 +62,7 @@
                     <div class="media-body">
                         <a href="/content/administrators/"><h2 class="media-heading"><i class="fas fa-users-cog administrators icon sm visible-xs-inline"></i>Administrators</h2></a>
                         <p>
-                            Hello, Administrator! Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-                             quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                            Hello, Administrator! This section encompasses documentation for both Admins and Super-Users (sometimes referred to as hosts). Administrators will handle tasks such as installing & upgrading DNN, configuring permissions and security roles, updating site settings, installing and updgrading extensions, and much more. 
                         </p>
                         <ul class="popular-topics">
                             <li style="border-bottom: 0;">Quick Links: </li>
@@ -90,8 +89,7 @@
                     <div class="media-body">
                         <a href="/content/content-managers"><h2 class="media-heading"><i class="fas fa-signature content-editors icon sm visible-xs-inline"></i>Content Managers</h2></a>
                         <p>
-                            Hello, Content Manager! Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-                             quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                            Hello, Content Manager! Content managers within DNN are users who create, edit, and maintain content. Content comes in all shapes and sizes. It may be text, images, videos and any type you can imagine. Content can be managed within the HTML module, various structured content modules, the digital asset manager, and custom or third party modules.
                         </p>
                         <ul class="popular-topics">
                             <li style="border-bottom: 0;">Quick Links: </li>
@@ -120,8 +118,7 @@
                     <div class="media-body">
                         <a href="/content/developers"><h2 class="media-heading"><i class="fas fa-code developers icon sm visible-xs-inline"></i>Developers</h2></a>
                         <p>
-                            Hello, Developer! Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-                             quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                            Hello, Developer! DNN has an open API and many extension points. Developers can create custom DNN extensions using various development approaches. The content in this section will help you get started and learn more about DNN's extensibility model and applicable development patterns. 
                         </p>
                         <ul class="popular-topics">
                             <li style="border-bottom: 0;">Quick Links: </li>
@@ -152,8 +149,7 @@
                     <div class="media-body">
                         <a href="/content/designers"><h2 class="media-heading"><i class="fas fa-fill-drip designers icon sm visible-xs-inline"></i>Designers</h2></a>
                         <p>
-                            Hello, Designer! Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-                             quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                            Hello, Designer! Designers can achieve any look and feel desired with DNN. The content in this section will help designers and front-end developers alike understand the process for creating themes (formerly referred to as "skins") within DNN. If you can design it in Photoshop you can create it with a DNN theme!
                         </p>
                         <ul class="popular-topics">
                             <li style="border-bottom: 0;">Quick Links: </li>


### PR DESCRIPTION
The [SEO > SITEMAPS > CONFIGURE SITEMAP page](https://dnndocs.com/content/administrators/sitemaps/configure-sitemap/index.html) had a table cell that wasn't properly formatted. I updated the formatting to fix this.

I also moved the "TIP" callout beneath the table and added in the proper markdown formatting so the callout would render properly.