### PR TITLE
Updated 'NOTE' Callout syntax to be appropriate markdown

### DIFF
--- a/content/administrators/configuring-your-site/configure-check-for-new-version/index.md
+++ b/content/administrators/configuring-your-site/configure-check-for-new-version/index.md
@@ -13,7 +13,8 @@ related-topics: update-site-info,assign-key-pages,add-metadata-to-pages,configur
 
 You can choose to be automatically notified if DNN releases a newer version.
 
-Note: This setting only triggers a notification. It does not perform the upgrade.
+> [!Note]
+> This setting only triggers a notification. It does not perform the upgrade.
 
 ## Prerequisites
 


### PR DESCRIPTION
At the top of this page there was a "NOTE" callout that wasn't using the proper markdown syntax. I updated it.