### PR TITLE
Updated image URL downcasing it so there is no broken image - Edit Article in Browser Page

### DIFF
--- a/content/contribute/docs/how-to-edit-an-article-in-browser/index.md
+++ b/content/contribute/docs/how-to-edit-an-article-in-browser/index.md
@@ -23,7 +23,7 @@ The easiest way to edit a DNN Doc file is to edit it in the browser on GitHub.co
 
 3. Edit the markdown as needed, opt to "Create a New Branch", and propose the change.
 
-![Edit Markdown in browser](/images/In-Browser-Pull-Request.gif)
+![Edit Markdown in browser](/images/in-browser-pull-request.gif)
 
 
 


### PR DESCRIPTION
Since DNN Docs is case sensitive there is currently a broken image link on [this page](https://dnndocs.com/content/contribute/docs/how-to-edit-an-article-in-browser/index.html) because the image URL is camel-cased. This update down-cases it and fixes the image so it will show up.