### PR TITLE
Make community events logos visible on mobile Resolved #169

### DIFF
--- a/templates/dnn-docs/index.html.tmpl
+++ b/templates/dnn-docs/index.html.tmpl
@@ -220,25 +220,25 @@
                     <p>Learn more about DNN at these community events:</p>
                     <ul class="events-list text-center">
                         <li>
-                            <a class="visible-lg visible-xl" href="https://www.dnnsummit.org/" target="_blank">
+                            <a href="https://www.dnnsummit.org/" target="_blank">
                                 <img src="images/2019-SummitLogo.png">
                             </a>
                             <span class="details">Feb 19-23 2019<br>Denver</span>
                         </li>
                         <li>
-                            <a class="visible-lg visible-xl" href="https://www.dnn-connect.org/" target="_blank">
+                            <a href="https://www.dnn-connect.org/" target="_blank">
                                 <img src="images/dnnconnect-logo.png">
                             </a>
                             <span class="details">Jun 6-9 2019<br>Champery</span>
                         </li>
                         <li>
-                            <a class="visible-lg visible-xl" href="http://www.southernfrieddnn.com/" target="_blank">
+                            <a href="http://www.southernfrieddnn.com/" target="_blank">
                                 <img src="images/southernfried-logo.jpg">
                             </a>
                             <span class="details">3rd Thurs monthly<br>(online)</span>
                         </li>
                         <li>
-                            <a class="visible-lg visible-xl" href="https://www.meetup.com/Toronto-Area-DNN-User-Group-TADUG/" target="_blank">
+                            <a href="https://www.meetup.com/Toronto-Area-DNN-User-Group-TADUG/" target="_blank">
                                 <img src="images/tadug-logo.jpg">
                             </a>
                             <span class="details">1st Wed monthly<br>(online)</span>


### PR DESCRIPTION
Previous code was set to only show images on `lg` and `xl`. I removed the appropriate classes so they show on all screen sizes.