### PR TITLE
Updated Casing of Image Src to Fix broken image

### DIFF
--- a/content/contribute/docs/markdown-guide-to-docfx/index.md
+++ b/content/contribute/docs/markdown-guide-to-docfx/index.md
@@ -17,7 +17,7 @@ For example, you’ll do things like ```**A BOLDED WORD**``` instead of typing `
 > [!TIP]
 > Here’s a [markdown cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) to help you get started.
 
-![Markdown Syntax](/images/markdown.jpg)
+![Markdown Syntax](/images/Markdown.jpg)
 
 ## Front Matter 
 


### PR DESCRIPTION
There was a broken image on the [Markdown Guide to DocFx](https://dnndocs.com/content/contribute/docs/markdown-guide-to-docfx/index.html) at the top of the page. This was caused by the case sensitivity in the system. I changed the lower case m to a an upper case M in the src "Markdown.jpg". This makes the image show in the doc file now.