### PR TITLE
Updated PB image on Configure a Navigation Link to an Existing Page

### DIFF
--- a/content/administrators/pages-templates/configure-page-existing/index.md
+++ b/content/administrators/pages-templates/configure-page-existing/index.md
@@ -15,7 +15,7 @@ related-topics: create-single-page-standard,create-single-page-existing,create-s
 
 1.  Go to **Persona Bar \> Content \> Pages**.
     
-    ![Persona Bar > Content > Pages](/images/scr-pbar-host-Content-E91.png)
+    ![Persona Bar > Content > Pages](/images/scr-pbar-host-Content-E91-platform.png)
     
 2.  In the **Pages** page, hover over the page to configure, then click/tap the gear icon.
     


### PR DESCRIPTION
This PR addresses issue #199 by updating the PB image from the Evoq UI to the Platform UI on the Configure a Navigation Link to an Existing Page page