### PR TITLE
Updated the Restore Deleted Templates Page adding in a callout ababou…

### DIFF
--- a/content/administrators/recyclebin/restore-deleted-templates/index.md
+++ b/content/administrators/recyclebin/restore-deleted-templates/index.md
@@ -11,6 +11,9 @@ related-topics: create-template-based-on-page-pb-all,create-template-based-on-an
 
 # Restore Deleted Templates
 
+ > [!NOTE]
+ > Restoring deleted templates is an Evoq only feature
+
 ## Steps
 
 1.  Go to **Persona Bar \> Content \> Recycle Bin**.


### PR DESCRIPTION
This PR is related to issue #199 in that I went in to update the PB image from Evoq UI to Platform UI, but looked in a platform site and noticed the feature was not present. Therefore I updated the page adding in a NOTE! callout at the top of the page denoting this feature is an evoq-only feature.