### PR TITLE
Added Evoq only feature callout note on Purge Deleted Templates page

### DIFF
--- a/content/administrators/recyclebin/purge-deleted-templates/index.md
+++ b/content/administrators/recyclebin/purge-deleted-templates/index.md
@@ -11,6 +11,9 @@ related-topics: create-template-based-on-page-pb-all,create-template-based-on-an
 
 # Purge Deleted Templates
 
+> [!NOTE]
+> Purging deleted templates is an evoq only feature
+
 ## Steps
 
 1.  Go to **Persona Bar \> Content \> Recycle Bin**.


### PR DESCRIPTION
This PR is related to issue #199 as I went to update the PB image from Evoq UI to Platform UI but the feature does not exist in platform. As such I added a NOTE! callout to the page indicating the feature was an evoq-only feature.