### PR TITLE
Added starter content on Designer/Developer landing pages

### DIFF
--- a/content/designers/index.md
+++ b/content/designers/index.md
@@ -1,1 +1,10 @@
-﻿# Designers
+﻿---
+uid: designers-home
+locale: en
+title: Designers
+dnnversion: 09.02.00
+related-topics: create-theme
+---
+
+# Designers
+Hello, Designer! Designers can achieve any look and feel desired with DNN. The content in this section will help designers and front-end developers alike understand the process for creating themes (formerly referred to as "skins") within DNN. If you can design it in Photoshop you can create it with a DNN theme!

--- a/content/developers/index.md
+++ b/content/developers/index.md
@@ -1,1 +1,10 @@
-﻿# Developers
+﻿---
+uid: developers-home
+locale: en
+title: Developers
+dnnversion: 09.02.00
+related-topics: creating-modules
+---
+
+# Developers
+Hello, Developer! DNN has an open API and many extension points. Developers can create custom DNN extensions using various development approaches. The content in this section will help you get started and learn more about DNN's extensibility model and applicable development patterns.


### PR DESCRIPTION
The Designer & Developer landing pages are currently blank. This PR simply adds the intro paragraph that exists on the home page sections to the Designer and Developer landing pages. It also added front-matter to the index docs as it was missing.