### PR TITLE
Fixed the Product-Version / Releases debacle & updated git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,8 @@ mono_crash.*
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/
-[Rr]elease/
-[Rr]eleases/
+/plugins/**/[Rr]elease/
+/plugins/**/[Rr]eleases/
 x64/
 x86/
 [Aa][Rr][Mm]/

--- a/content/administrators/releases/index.md
+++ b/content/administrators/releases/index.md
@@ -1,12 +1,12 @@
 ﻿---
-uid: product-versions
+uid: releases
 locale: en
-title: Product Versions
+title: Releases
 dnnversion: 09.03.02
 related-topics: administrators-included-modules-overview,requirements,dnn-overview,control-bar-to-persona-bar,persona-bar-by-role,providers,more-resources
 ---
 
-# Product Versions
+# Releases
 
 ## History
 


### PR DESCRIPTION
Attempt number 2 at fixing this. 

You should see:

- updated git ignore file to allow a folder with the name "Releases" to be used
- a folder named Product-Versions which was renamed to "Releases"
- updated UID in the index.md file
- some updated headings in the index.md file