### PR TITLE
Updated h4 to NOTE to fix sub-menu rendering

### DIFF
--- a/content/designers/theme-objects/index.md
+++ b/content/designers/theme-objects/index.md
@@ -109,8 +109,8 @@ ASCX Theme
 Where the "Register" block should be on top of the ASCX file.
 The <dnn:BREADCRUMB...> block should be placed in the Theme on the spot you want it to appear.
 
-
-#### The following list is far from complete (some work to be done) and some of the Theme Objects in the list are legacy
+> [!NOTE]
+> The following list is far from complete (some work to be done) and some of the Theme Objects in the list are legacy
 
 |**Theme Object**|**Description**|
 |---|---|


### PR DESCRIPTION
Timo made an update earlier that was good. Though, he included a note to the reader as an H4 which causes the right-hand (automatically generated) sub-nav to have the text running off the page. I updated this to make it a NOTE so as to be more visually compelling and to not cause sub-menu to run off page. 

#thankswill 