### PR TITLE
update tutorials toc

### DIFF
--- a/content/guides/tutorials/maintaining-your-servers/index.md
+++ b/content/guides/tutorials/maintaining-your-servers/index.md
@@ -1,0 +1,9 @@
+﻿---
+uid: maintaining-your-servers
+locale: en
+title: Maintaining Your Servers
+dnnversion: 09.02.00
+related-topics:
+---
+
+# Maintaining Your Servers

--- a/content/guides/tutorials/toc.md
+++ b/content/guides/tutorials/toc.md
@@ -12,7 +12,7 @@
 ## [Security](xref:platform-overview-security)
 
 <!-- START OF "MAINTAINING YOUR SERVERS" NAV ITEM -->
-
+# [Maintaing Your Servers](xref:maintaining-your-servers)
 ## [SMTP Servers](xref:smtp-servers)
 ## [Server Performance](xref:server-performance)
 
@@ -264,10 +264,6 @@
 
 <!--Developers-->
 # [Setting Up DNN](xref:set-up-dnn)
-
-# [Platform Overview](xref:platform-overview-overview)
-## [Core Platform Objects](xref:platform-overview-core-objects)
-## [Security](xref:platform-overview-security)
 
 # [Beginning Module Development](xref:beginning-module-development-overview)
 ## [A Guided Tour of Your Work Environment](xref:mod-dev-work-environment)


### PR DESCRIPTION
# About

This cleans up the table of contents for Tutorials.

# Change Summary

  * Remove duplicate "Platform Overview" section.
  * Move "Maintaining Your Servers" section out from under remaining "Platform Overview" section.
  * Create an empty *index.md* under `./content/guides/tutorials/maintaining-your-servers/` as a stub for now.