### PR TITLE
update main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,33 +5,38 @@ The documentation site for the open source Content Management System DNN (former
 The project uses the `docfx` library to pull XML comments from the DNN Platform source code and combine that with articles written in Markdown to form the documentation for DNN.
 
 ## Installing Git
-If you do not have Git installed you will need to install Git first. You can find instructions on installing Git from [here](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+If you do not have Git installed, you will need to install it first. You can find instructions at [Git's Installation Guide](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
 
 ## Installing DocFX
-DocFX may be installed on Windows via _Chocolatey_ by calling `choco install docfx -y`
+You'll also need DocFX installed as a command-line tool.  This can be accomplished using
 
-If you are on MacOS you can install it with _Homebrew_ `brew install docfx`
+  * [Chocolatey](https://chocolatey.org/) for Windows via `choco install docfx -y`
+  * [Homebrew](https://brew.sh/) for macOS via `brew install docfx`
 
-Or you can download and unzip `docfx.zip` from [GitHub](https://github.com/dotnet/docfx/releases), extract it to a folder and then set your `PATH` to that folder so you can run it anywhere.
+Alternatively, you can download the latest release of `docfx.zip` from [DocFX's GitHub Releases](https://github.com/dotnet/docfx/releases), extract it to a local directory, and add that directory to `PATH` so you can run it anywhere.
 
 ## Setting Up the DNN Docs Project
-After installing DocFX, the next step is to clone this repo.  'Cloning the repo' will simply create a copy of the repo (files and folders) on your local machine so that you can work with them.
+After installing DocFX, the next step is to clone this repository from GitHub to your local machine.  This will create a copy of the DNNDocs Git repository (its directories and folders) on your local machine so that you can work with them there.
 
-Note the following example command clones the repo to the location of `c:\dev`. Update the `c:\dev` location to your location of choice on your machine.
-```
-c:\dev> git clone https://github.com/DNNCommunity/DNNDocs.git
-```
+The following command will clone this repository to your working directory, so you may wish to `cd` to an appropriate directory first.
 
-The previous command will have created a folder called `DNNDocs` in the `c:\dev` folder. Navigate to that directory by using the cd (Change Directory) command. `cd` into the `DNNDocs` folder.
 ```
-c:\dev> cd DNNDocs
+git clone https://github.com/DNNCommunity/DNNDocs.git
 ```
 
-Next, you'll need to fork and/or clone the [Dnn.Platform repository](https://github.com/dnnsoftware/Dnn.Platform) into a **sub-folder** of the `DNNDocs` root folder. The reason is that the project reads the XML comments in the source code and creates API documentation from that, in addition to the documentation center articles.
+The previous command will have created a folder titled `DNNDocs` in your working directory.  So, for example, if you had been working in `C:\dev\`, the previous command would have created `C:\dev\DNNDocs\`.
 
-Please note this could take a few minutes depending on your connection speed.
 ```
-c:\dev\dnn-docs>git clone https://github.com/dnnsoftware/Dnn.Platform.git
+cd DNNDocs
+```
+
+Next, you'll need to clone the [Dnn.Platform repository](https://github.com/dnnsoftware/Dnn.Platform) into a **subdirectory** of `DNNDocs` so that DocFX can parse its source code for structured XML comments to generate DNN's API documentation and the documentation center articles.
+
+Navigate into the newly created `DNNDocs` directory and clone the *Dnn.Platform*.  This could take a few minutes depending on your connection speed.
+
+```
+cd DNNDocs
+git clone https://github.com/dnnsoftware/Dnn.Platform.git
 ```
 
 ## Running the DNN Docs Project Locally
@@ -41,12 +46,11 @@ You should now be able to run the development version of the docs locally with t
 docfx --serve
 ```
 
-[!NOTE]
-You should run your shell in administrator mode for this to work!
+If you installed `docfx` using Chocolatey for Windows, you will need to run your shell as an administrator.
 
-The first time, the compilation process could take quite a while. You may see a couple of warning messages. Eventually, you should see a message similar to:
+The compilation process could take quite a while.  You may see some warning messages.  Eventually, you should see a message similar to:
 ```
-Serving "C:\dev\DNNDocs\_site" on https://localhost:8080
+Serving "C:\dev\DNNDocs\_site" on http://localhost:8080
 ```
 
-Open that page up in your browser to see the documentation.
+You can now open <a href="http://localhost:8080" target="_blank">http://localhost:8080</a> in your web browser to view your local DNNDocs app.


### PR DESCRIPTION
# About

This cleans up the project's primary README.md.

# Change Summary

  * Add links for Chocolatey and Homebrew.
  * Change localhost url to use `http` instead of `https` to match docfx's documentation: https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html#2-use-docfx-as-a-command-line-tool
  * Update overall prose to clarify instructions and keep the tone more consistent.

# Notes

I didn't see any guidelines for submitting pull requests here.  Let me know if you'd prefer to have future PRs formatted/structured in some way.

I attempted to get this running on Linux (Mint) using [Homebrew for Linux](https://docs.brew.sh/Homebrew-on-Linux) to install `docfx` but ran into some snags.  [This DocFX issue](https://github.com/dotnet/docfx/issues/1027) suggests that a manual installation is possible, but I haven't tried.