### PR TITLE
Issues/issue 348

### DIFF
--- a/content/guides/tutorials/creating-modules/create-module-using-templates/index.md
+++ b/content/guides/tutorials/creating-modules/create-module-using-templates/index.md
@@ -38,4 +38,4 @@ links: ["[DNN API Reference](https://www.dnnsoftware.com/dnn-api/)","[DNN Wiki: 
 
         This build creates an installation zip file (your module's package) in the folder Desktop Modules/yourorganization/yourmodule/install.
 
-    5.  Alternatively, you can manually [pack your module](xref:developers-pack-extension).
+    5.  Alternatively, you can manually [pack your module](xref:pack-extension).

--- a/content/guides/tutorials/developer-references/image-handler/index.md
+++ b/content/guides/tutorials/developer-references/image-handler/index.md
@@ -72,7 +72,7 @@ You can also apply filters to the images
 * [Contrast](#contrast-filter)
 * [Gamma](#gamma-filter)
 * [Brightness](#brightness-filter)
-* [Rotate/Flip](#rotate-flip-filter)
+* [Rotate/Flip](#rotateflip-filter)
 
 ### Greyscale Filter
 

--- a/content/guides/tutorials/dnn-overview/index.md
+++ b/content/guides/tutorials/dnn-overview/index.md
@@ -42,4 +42,3 @@ The DNN Documentation Center is organized based on these persona groups:
 *   [Developers](http://dnndocs.com/content/developers/)
 *   [Designers](http://dnndocs.com/content/designers/)
 *   [Content Managers](http://dnndocs.com/content/content-managers/) includes content managers, editors, and creators.
-*   Community Managers

--- a/content/guides/tutorials/dnn-overview/index.md
+++ b/content/guides/tutorials/dnn-overview/index.md
@@ -42,4 +42,4 @@ The DNN Documentation Center is organized based on these persona groups:
 *   [Developers](http://dnndocs.com/content/developers/)
 *   [Designers](http://dnndocs.com/content/designers/)
 *   [Content Managers](http://dnndocs.com/content/content-managers/) includes content managers, editors, and creators.
-*   [Community Managers](http://dnndocs.com/content/community-managers/)
+*   Community Managers

--- a/content/guides/tutorials/extensions/developers-extensions-overview/index.md
+++ b/content/guides/tutorials/extensions/developers-extensions-overview/index.md
@@ -14,7 +14,7 @@ Before you create an extension, it's worth your time to first check to see if th
 * [DNN Store](https://store.dnnsoftware.com/)
 * [Search GitHub](https://github.com/search?q=dnn)
 * [Use nvQuickPulse to find an Extensionn](https://github.com/nvisionative/nvQuickPulse/blob/master/README.md)
-* [Look through the DNN-Connect directory](https://www.dnn-connect.org/community/community-extensions)
+* [Look through the DNN Forge](https://dnncommunity.org/forge)
 
 # Types of Extensions
 

--- a/content/guides/tutorials/glossary/index.md
+++ b/content/guides/tutorials/glossary/index.md
@@ -6,4 +6,4 @@ dnnversion: 09.02.00
 links: ["[DNN Wiki: DNN Glossary](https://www.dnnsoftware.com/wiki/dotnetnuke-glossary)","[DNN Wiki: Globalization Glossary](https://www.dnnsoftware.com/wiki/international-glossary)"]
 ---
 
-[!include[](../../common/glossary/index.md)]
+[!include[](../../../common/glossary/index.md)]

--- a/content/guides/tutorials/toc.md
+++ b/content/guides/tutorials/toc.md
@@ -238,10 +238,6 @@
 ## [DNN Security](xref:dnn-security)
 ## [More Resources](xref:more-resources)
 
-<!-- START OF "GLOSSSARY" NAV ITEM -->
-# [Glossary](xref:admin-glossary)
-
-
 <!--Content Managers-->
 #[Content with Modules](xref:content-managers-content-with-modules-overview)
 #[Extensions](xref:content-managers-extensions-overview)

--- a/content/guides/tutorials/toc.md
+++ b/content/guides/tutorials/toc.md
@@ -1,3 +1,5 @@
+# [DNN Solutions](xref:dnn-overview)
+
 <!--Administrators-->
 <!-- START OF "SETTING UP DNN" NAV ITEM -->
 # [Setting Up DNN](xref:administrators-setup-overview)

--- a/templates/dnn-docs/index.html.tmpl
+++ b/templates/dnn-docs/index.html.tmpl
@@ -45,7 +45,7 @@
                                             <ul>
                                                 <li><a href="/content/guides/tutorials/dnn-overview/index.html">What is DNN?</a></li>
                                                 <li><a href="/content/guides/tutorials/setup/set-up-dnn-folder/index.html">Install/Upgrade</a></li>
-                                                <li><a href="/content/administrators/product-versions/index.html">Version History</a></li>
+                                                <li><a href="/content/reference/releases/index.html">Version History</a></li>
                                             </ul>
                                         </div>
                                         <div class="col-sm-4">

--- a/templates/dnn-docs/index.html.tmpl
+++ b/templates/dnn-docs/index.html.tmpl
@@ -45,7 +45,7 @@
                                             <ul>
                                                 <li><a href="/content/guides/tutorials/dnn-overview/index.html">What is DNN?</a></li>
                                                 <li><a href="/content/guides/tutorials/setup/set-up-dnn-folder/index.html">Install/Upgrade</a></li>
-                                                <li><a href="/content/guides/tutorials/product-versions/index.html">Version History</a></li>
+                                                <li><a href="/content/administrators/product-versions/index.html">Version History</a></li>
                                             </ul>
                                         </div>
                                         <div class="col-sm-4">


### PR DESCRIPTION
The "Improve this Doc" links appear to be a separate/more complicated issue than simply resolving broken links.  I'm suggesting that those 4 links should be fixed in a separate issue and PR.  

In the meantime, this PR does the following:

- Fixed broken links on known pages discovered in scan
- Removed the duplicate (broken) glossary link from the TOC
- Resolved broken xref link reported during build
- Resolved broken bookmark reported during build
- Resolved broken path reference reported during build

Resolves issue #348 