### PR TITLE
Update site logo

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -43,7 +43,7 @@
     ],
     "dest": "_site",
     "globalMetadata": {
-      "_appLogoPath": "images/dnn_docs_logo-preview.png",
+      "_appLogoPath": "images/dnn_docs_logo.png",
       "_gitContribute": {
         "repo": "https://github.com/DNNCommunity/DNNDocs.git",
         "branch": "master"


### PR DESCRIPTION
Replace DNN Docs "Preview" logo with the official logo.
Resolves #390