### PR TITLE
Fixing Home Page Links w /guides/

### DIFF
--- a/templates/dnn-docs/index.html.tmpl
+++ b/templates/dnn-docs/index.html.tmpl
@@ -51,7 +51,7 @@
                                         <div class="col-sm-4">
                                             <h4 class="hlead">Extend DNN</h4>
                                             <ul>
-                                                <li><a href="/content/guides/tutorials/themes/creating-themes/designers-creating-themes-overview/index.html">Creating Themes</a></li>
+                                                <li><a href="/content/tutorials/themes/creating-themes/designers-creating-themes-overview/index.html">Creating Themes</a></li>
                                                 <li><a href="/content/features/extensions/index.html">Creating Extensions</a></li>
                                                 <li><a href="/api/">DNN API</a></li>
                                             </ul>
@@ -100,9 +100,9 @@
                                         </p>
                                         <ul class="popular-topics">
                                             <li style="border-bottom: 0;">Quick Links: </li>
-                                            <li><a href="/content/guides/tutorials/server/setup/administrators-setup-overview/index.html">Setting Up DNN</a></li>
-                                            <li><a href="/content/guides/tutorials/sites/configuring-your-site/configuring-your-site/index.html">Configuring Your Site</a></li>
-                                            <li><a href="/content/guides/tutorials/troubleshooting/administrators-troubleshooting-overview/index.html">Troubleshooting</a></li>
+                                            <li><a href="/content/tutorials/server/setup/administrators-setup-overview/index.html">Setting Up DNN</a></li>
+                                            <li><a href="/content/tutorials/sites/configuring-your-site/configuring-your-site/index.html">Configuring Your Site</a></li>
+                                            <li><a href="/content/tutorials/troubleshooting/administrators-troubleshooting-overview/index.html">Troubleshooting</a></li>
                                         </ul>
                                     </div>
                                 </div>
@@ -130,9 +130,9 @@
                                         <ul class="popular-topics">
                                             <li style="border-bottom: 0;">Quick Links: </li>
                                             <li><a href="/content/features/modules/index.html">Module (Extensions) Development</a></li>
-                                            <li><a href="/content/guides/tutorials/modules/mvc-modules/mvc-module-project-overview/index.html">MVC Module Development</a></li>
-                                            <li><a href="/content/guides/tutorials/modules/about-modules/spa-module-development/index.html">SPA Module Development</a></li>
-                                            <li><a href="/content/guides/tutorials/modules/about-modules/web-forms-module-development/index.html">Web Forms Module Development</a></li>
+                                            <li><a href="/content/tutorials/modules/mvc-modules/mvc-module-project-overview/index.html">MVC Module Development</a></li>
+                                            <li><a href="/content/tutorials/modules/about-modules/spa-module-development/index.html">SPA Module Development</a></li>
+                                            <li><a href="/content/tutorials/modules/about-modules/web-forms-module-development/index.html">Web Forms Module Development</a></li>
                                         </ul>
                                     </div>
                                 </div>
@@ -160,8 +160,8 @@
                                         </p>
                                         <ul class="popular-topics">
                                             <li style="border-bottom: 0;">Quick Links: </li>
-                                            <li><a href="/content/guides/tutorials/themes/creating-themes/designers-creating-themes-overview/index.html">Creating Themes</a></li>
-                                            <li><a href="/content/guides/tutorials/themes/persona-bar-style-guide/index.html">Persona Bar Style Guide</a></li>
+                                            <li><a href="/content/tutorials/themes/creating-themes/designers-creating-themes-overview/index.html">Creating Themes</a></li>
+                                            <li><a href="/content/tutorials/themes/persona-bar-style-guide/index.html">Persona Bar Style Guide</a></li>
                                         </ul>
                                     </div>
                                 </div>


### PR DESCRIPTION
Not sure I am doing this right, someone able to test/verify this?

Recently the path /guides/ was removed, so /tutorials and others are now directly below http://localhost:8080/content/

I found that the home page was being created from this template and manually fixed the links. Seems to work for me locally.

This should fix it so that links that still have /guides/ are pointing to the current/real pages.

Example from Home in the Designers section, Creating Themes currently goes here
https://www.dnndocs.com/content/guides/tutorials/themes/creating-themes/designers-creating-themes-overview/index.html

The above is WRONG, it should go here.
https://www.dnndocs.com/content/tutorials/themes/creating-themes/designers-creating-themes-overview/index.html