### PR TITLE
Quick fix to Tutorials/Sites linking in nav

### DIFF
--- a/content/tutorials/sites/index.md
+++ b/content/tutorials/sites/index.md
@@ -1,0 +1,12 @@
+---
+uid: tutorials-sites-overview
+locale: en
+title: Sites, Overview | Tutorials
+dnnversion: 09.02.00
+---
+
+# Sites
+
+## Overview
+
+DNN is multi-site ready. In a single DNN instance you can easily add multiple sites, known as Portals, and assign each an individual URL (domain, subdomain, etc.) In this section you can find more info on Managing Sites, Configuring each site, and Building Your Site.

--- a/content/tutorials/toc.md
+++ b/content/tutorials/toc.md
@@ -10,7 +10,7 @@
 ###[Server Performance](xref:server-performance)
 ##[SMTP Servers](xref:smtp-servers)
 
-#[Sites](xref:sites)
+#[Sites](xref:tutorials-sites-overview)
 ##[Managing Sites](xref:administrators-sites-overview)
 ###[Sites](xref:sites)
 ####[Create Site](xref:create-site)


### PR DESCRIPTION
Tiny fix to this nav weirdness. Probably needs to be cleaned up elsewhere too.

![fORBNgRM57](https://user-images.githubusercontent.com/653301/83361570-a8ebf000-a34f-11ea-88cb-00ebb2e2eaea.gif)
