### PR TITLE
Breadcrumbs: Generated changes, typo and example added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DNN Platform Documentation
 
-The documentation site for the open source Content Management System DNN (formerly DotNetNuke).
+The [documentation site](https://dnndocs.com/) for the open source Content Management System DNN (formerly DotNetNuke).
 
 The project uses the `docfx` library to pull XML comments from the DNN Platform source code and combine that with articles written in Markdown to form the documentation for DNN.
 

--- a/content/tutorials/themes/theme-objects/breadcrumb/index.md
+++ b/content/tutorials/themes/theme-objects/breadcrumb/index.md
@@ -12,9 +12,10 @@ links:
 # Breadcrumb Theme Object Introduction
 
 The Breadcrumb Theme Object displays the path to the currently selected page in the menu structure like this:
-RootPage > SubPage > SubSubPage
-The starting level, separator and styling are configurable.
 
+RootPage > SubPage > SubSubPage
+
+The starting level, separator and styling are configurable.
 
 **Current Version:** 01.00.00
 
@@ -41,7 +42,7 @@ The starting level, separator and styling are configurable.
 | --- | --- | --- | --- | --- |
 | Separator | The separator between breadcrumb links. | > | html / text / image | 01.00.00 |
 | CssClass | CSS Class of the SkinObject | SkinObject | A valid CSS Class | 01.00.00 |
-| RootLevel | The root level of the breadcrumb links. | 1 | Valid values include:<br/>-1 - show word “Root” and then all breadcrumb tabs<br/>0 - show all breadcrumb tabs<br/>n (Integer > 0) - skip n breadcrumb tabs before displaying | 01.00.00 |
+| RootLevel | The root level of the breadcrumb links. | 1 | Valid values include:<br /><br />-1 - show word “Root” and then all breadcrumb tabs<br /><br />0 - show all breadcrumb tabs<br /><br />n (Integer > 0) - skip n breadcrumb tabs before displaying | 01.00.00 |
 | UseTitle | Use the PageTitle instead of PageName | False | True / False | 01.00.00 |
 
 ## Examples:

--- a/content/tutorials/themes/theme-objects/index.md
+++ b/content/tutorials/themes/theme-objects/index.md
@@ -4,7 +4,7 @@ locale: en
 title: Theme Objects
 dnnversion: 09.02.00
 related-topics: create-layout-template,create-container,create-theme
-links: ["[DNN UX Guide](https://uxguide.dnnsoftware.com/)","[DotNetNuke Skinning Guide (Appendix B: Skin Objects) by Timo Breumelhof](https://www.timo-design.nl)","[Skinning Tool / Online Reference for DNN Skins & Container Objects by 10 Pound Gorilla](https://www.10poundgorilla.com)"]
+links: ["[DNN UX Guide](https://uxguide.dnnsoftware.com/)","[DotNetNuke Skinning Guide (Appendix B: Skin Objects) by Timo Breumelhof](https://www.timo-design.nl/Portals/0/downloads/DotNetNuke-Skin-Objects-DNN5.pdf)","[Skinning Tool / Online Reference for DNN Skins & Container Objects by 10 Pound Gorilla](https://www.10poundgorilla.com)"]
 ---
 
 # Theme Objects


### PR DESCRIPTION
I generated the Markdown from a Open Content template now (that should make creating these pages much easier), so it might be that I still need to make some changes to the template, but I can now generate these much easier
I also fixed a typo.
I plan to generate an example Theme using this markup in the future, which is why I will add simple and a more advanced example.