### PR TITLE
Resolves #553

### DIFF
--- a/templates/dnn-docs/styles/docfx.css
+++ b/templates/dnn-docs/styles/docfx.css
@@ -676,6 +676,7 @@ body .toc{
   padding-bottom: 10px;
   height: calc(100% - 100px);
   /*margin-right: -20px;*/
+  overflow-y: scroll;
 }
 .affix ul > li > a:before {
   color: #cccccc;


### PR DESCRIPTION
I added an overflow-y: scroll property to allow for scrolling in the right sidebar. The auto-scroll and affix behaviour still works as expected. The only difference is that you can now scroll in the list of methods in the tree.

Note: updating the stylesheet in the generated site may require calling `docfx --template`