### PR TITLE
DotNetNuke.Messaging extension should also be removed

### DIFF
--- a/content/getting-started/setup/telerik-removal/index.md
+++ b/content/getting-started/setup/telerik-removal/index.md
@@ -39,7 +39,7 @@ Navigate to `Settings > SQL Console` via the `Persona Bar` and run the following
 ```
 UPDATE {databaseOwner}{objectQualifier}Packages
 SET IsSystemPackage = 0
-WHERE Name IN ('DigitalAssetsManagement', 'DotNetNuke.Telerik.Web', 'DotNetNuke.Web.Deprecated', 'DotNetNuke.Website.Deprecated')
+WHERE Name IN ('DigitalAssetsManagement', 'DotNetNuke.Telerik.Web', 'DotNetNuke.Web.Deprecated', 'DotNetNuke.Website.Deprecated', 'DotNetNuke.Messaging`)
 GO
 
 DELETE FROM {databaseOwner}{objectQualifier}PackageDependencies
@@ -62,21 +62,24 @@ Navigate to `Settings > Servers` in the `Persona Bar` and click the `Clear Cache
 Navigate to `Settings > Extensions (Modules)` in the `Persona Bar` and uninstall the `Digital Assets Management` extension.  Be sure to check the `Delete Files` checkbox.
 
 ### Step 9
-Navigate to `Settings > Extensions (Libraries)` in the `Persona Bar` and uninstall the `DotNetNuke Telerik Web Components` extension.  Be sure to check the `Delete Files` checkbox.
+Navigate to `Settings > Extensions (Modules)` in the `Persona Bar` and uninstall the `Messaging` extension **if it exists**.  Be sure to check the `Delete Files` checkbox.
 
 ### Step 10
-Navigate to `Settings > Extensions (Libraries)` in the `Persona Bar` and uninstall the `DNN Deprecated Web Controls Library` extension.  Be sure to check the `Delete Files` checkbox.
+Navigate to `Settings > Extensions (Libraries)` in the `Persona Bar` and uninstall the `DotNetNuke Telerik Web Components` extension.  Be sure to check the `Delete Files` checkbox.
 
 ### Step 11
-Navigate to `Settings > Extensions (Libraries)` in the `Persona Bar` and uninstall the `DotNetNuke Deprecated Website Codebehind files` extension.  Be sure to check the `Delete Files` checkbox.
+Navigate to `Settings > Extensions (Libraries)` in the `Persona Bar` and uninstall the `DNN Deprecated Web Controls Library` extension.  Be sure to check the `Delete Files` checkbox.
 
 ### Step 12
+Navigate to `Settings > Extensions (Libraries)` in the `Persona Bar` and uninstall the `DotNetNuke Deprecated Website Codebehind files` extension.  Be sure to check the `Delete Files` checkbox.
+
+### Step 13
 Open the `SiteUrls.config` file within the site root and search for "Telerik".  Delete all rewrite rules, `<RewriteRule>...</RewriteRule>`, that reference it.
  
-### Step 13
+### Step 14
 Open the `web.config` file within the site root and search for "Telerik".  Delete any lines that reference it.
 
-### Step 14
+### Step 15
 Remove the old extension packages for the Telerik components just removed.  
 In the folder '\App_Data\ExtensionPackages', remove all packages starting with:  
 `Library_DotNetNuke.Telerik_*`  
@@ -84,5 +87,5 @@ In the folder '\App_Data\ExtensionPackages', remove all packages starting with:
 `Library_DotNetNuke.Website.Deprecated_*`  
 
  
-### Step 15
+### Step 16
 Test all third-party modules to make sure they still work without Telerik.  If any do not work properly, please contact the developer/vendor for further guidance.


### PR DESCRIPTION
I'm finding older sites that have been upgraded still have the Messaging extension (v 6.1.5) as well as the Message Center extension.

It's still a System Extension on my longer living installs