### PR TITLE
Fixed the deployment target

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -118,9 +118,10 @@ class Build : NukeBuild
     Target Deploy => _ => _
         .DependsOn(Compile)
         .Executes(() => {
+            var currentCommit = GitCurrentCommit();
             Git("checkout site");
-            Git("checkout master -- _site");
             Git("add _site");
             Git("commit -m \"Commiting latest build\"");
+            Git("push origin site");
         });
 }


### PR DESCRIPTION
This should fix our deploy target to actually push to the site branch. Github actions used detached mode to we need to refer to the commit instead of master as _site folder does not exist on master