### PR TITLE
Changed build output from _site to docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ Dnn.Platform/
 /dist
 /tmp
 /obj
-/_site
+/docs
 /api/*.yml
 /api/*.manifest
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -56,7 +56,7 @@ class Build : NukeBuild
     const string pluginsProjectName = "DNNCommunity.DNNDocs.Plugins";
 
     // Define directories
-    AbsolutePath siteDirectory = RootDirectory / "_site";
+    AbsolutePath siteDirectory = RootDirectory / "docs";
     AbsolutePath pluginsDirectory = RootDirectory / "templates" / "dnn-docs" / "plugins";
     AbsolutePath dnnPlatformDirectory = RootDirectory / "Dnn.Platform";
 
@@ -126,8 +126,9 @@ class Build : NukeBuild
             Git("config --global user.email 'info@dnncommunity.org'");
             Git($"remote set-url origin https://DNNCommunity:{GithubToken}@github.com/DNNCommunity/DNNDocs.git");
             Git("checkout site");
-            Git("add _site");
+            Git("add docs");
             Git("commit -m \"Commiting latest build\"");
             Git("push origin site");
+            Git($"git checkout {currentCommit}");
         });
 }

--- a/docfx.json
+++ b/docfx.json
@@ -51,7 +51,7 @@
         "exclude": ["obj/**", "_site/**"]
       }
     ],
-    "dest": "_site",
+    "dest": "docs",
     "globalMetadata": {
       "_appLogoPath": "images/dnn_docs_logo.png",
       "_gitContribute": {


### PR DESCRIPTION
Github only supports using either the root or the docs folder for pages.