### PR TITLE
Minor tweak to CI to on checkout docs folder

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -136,7 +136,7 @@ class Build : NukeBuild
             Git("config --global user.email 'info@dnncommunity.org'");
             Git($"remote set-url origin https://DNNCommunity:{GithubToken}@github.com/DNNCommunity/DNNDocs.git");
             Git("status");
-            Git("checkout -b site");
+            Git("checkout -b site -- docs");
             Git("status");
             Git("add docs");
             Git("status");

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -136,9 +136,9 @@ class Build : NukeBuild
             Git("config --global user.email 'info@dnncommunity.org'");
             Git($"remote set-url origin https://DNNCommunity:{GithubToken}@github.com/DNNCommunity/DNNDocs.git");
             Git("status");
-            Git("checkout -b site -- docs");
+            Git("checkout -b site");
             Git("status");
-            Git("add docs");
+            Git("add docs -f");
             Git("status");
             Git("commit --allow-empty -m \"Commiting latest build\"");
             Git("status");


### PR DESCRIPTION
The `.gitignore` file is causing the `docs` folder to not be added.  So instead of checking out the entire detached head branch commit, let's try just checking out the `docs` folder.  Otherwise, we would need to do `git add docs -f` to force add the `docs` folder.