### PR TITLE
Return to deploy branch when the deploy is done

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -164,5 +164,6 @@ class Build : NukeBuild
             Git("commit --allow-empty -m \"Commit latest build\"");
             Git("status");
             Git("push origin site"); // Should push only the change with linear history and a proper diff.
+            Git("checkout deploy");
         });
 }


### PR DESCRIPTION
This prevents and error about the batch file no longer existing.