### PR TITLE
Rebuild `yaml` files for GitHub workflows

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -19,7 +19,7 @@ name: Deploy
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   windows-latest:

--- a/.github/workflows/PR_Validation.yml
+++ b/.github/workflows/PR_Validation.yml
@@ -19,7 +19,7 @@ name: PR_Validation
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   windows-latest:


### PR DESCRIPTION
The `yaml` files for GitHub workflows needed to be regenerated after changing the `master` branch to `main` in `build.cs` 