### PR TITLE
Fixed Problem with bracket facing the wrong way breaking a link.

### DIFF
--- a/content/getting-started/toc.md
+++ b/content/getting-started/toc.md
@@ -16,7 +16,7 @@
 #### [Web API](xref:getting-started-development-fundamentals-dependency-injection-web-api)
 #### [WebForms](xref:getting-started-development-fundamentals-dependency-injection-webforms)
 # [Contribution](xref:getting-started-contribution)
-## [Contribute to DNN Platform[(https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md)
+## [Contribute to DNN Platform](https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md)
 ## [Contribute to DNN Docs](xref:contribute-to-docs)
 ### [Edit an Article](xref:how-to-edit-an-article)
 ### [Edit an Article in the Browser](xref:how-to-edit-an-article-in-browser)


### PR DESCRIPTION
I noticed this problem with the link which prevented it from working and displaying correctly.
![Correct](https://user-images.githubusercontent.com/44900498/154382518-bcde2374-94b1-4903-9bf6-379257fae48e.PNG)
![Wrong](https://user-images.githubusercontent.com/44900498/154382520-cfcb0fb0-df64-43a1-a249-7b3ba90a7853.PNG)
.