### PR TITLE
Added more logging to RepoStats plugin

### DIFF
--- a/plugins/DNNCommunity.DNNDocs.Plugins/Providers/GitHubApi.cs
+++ b/plugins/DNNCommunity.DNNDocs.Plugins/Providers/GitHubApi.cs
@@ -41,7 +41,7 @@ namespace DNNCommunity.DNNDocs.Plugins.Providers
         {
             if (string.IsNullOrEmpty(gitHubToken))
             {
-                return null;
+                return new List<Contributor>();
             }
 
             var contributorsEndpoint = "https://api.github.com/repos/DNNCommunity/DNNDocs/contributors";
@@ -49,7 +49,7 @@ namespace DNNCommunity.DNNDocs.Plugins.Providers
 
             if (string.IsNullOrEmpty(resultsAsJson))
             {
-                return null;
+                return new List<Contributor>();
             }
 
             var contributors = JsonConvert.DeserializeObject<List<Contributor>>(resultsAsJson);
@@ -61,7 +61,7 @@ namespace DNNCommunity.DNNDocs.Plugins.Providers
 
             if (string.IsNullOrEmpty(gitHubToken))
             {
-                return null;
+                return new List<Commits>();
             }
             
             var commitsEndpoint = "https://api.github.com/repos/DNNCommunity/DNNDocs/commits";
@@ -72,7 +72,7 @@ namespace DNNCommunity.DNNDocs.Plugins.Providers
             var resultsAsJson = MakeRequest(commitsEndpoint, gitHubToken);
             if (string.IsNullOrEmpty(resultsAsJson))
             {
-                return null;
+                return new List<Commits>();
             }
 
             var commits = JsonConvert.DeserializeObject<List<Commits>>(resultsAsJson);
@@ -131,12 +131,17 @@ namespace DNNCommunity.DNNDocs.Plugins.Providers
         private string GetToken()
         {
             var filePath = Path.Combine(this.rootPath, "github-token.txt");
+            Console.WriteLine($"Loading token from: {filePath}");
             if (!File.Exists(filePath))
             {
-                return null;
+                Console.WriteLine($"The token file does not exist");
+                return String.Empty;
             }
-            
-            return File.ReadAllText(filePath);
+
+            var contents = File.ReadAllText(filePath);
+            Console.WriteLine($"Token file length was {contents.Length}");
+
+            return contents;
         }
     }
 }

--- a/plugins/DNNCommunity.DNNDocs.Plugins/RepoStatsBuildStep.cs
+++ b/plugins/DNNCommunity.DNNDocs.Plugins/RepoStatsBuildStep.cs
@@ -6,6 +6,7 @@ using Microsoft.DocAsCode.Plugins;
 using Microsoft.DocAsCode.Build.ConceptualDocuments;
 using DNNCommunity.DNNDocs.Plugins.Models;
 using DNNCommunity.DNNDocs.Plugins.Providers;
+using System;
 
 namespace DNNCommunity.DNNDocs.Plugins
 {
@@ -26,9 +27,14 @@ namespace DNNCommunity.DNNDocs.Plugins
         #region Postbuild
         public void Postbuild(ImmutableList<FileModel> models, IHostService host)
         {
+            Console.WriteLine($"Processing Repo Stats for {models.Count()} models");
             var rootPath = models[0].BaseDir;
+            
             List<Contributor> gitContributors = GitHubApi.Instance(rootPath).GetContributors(models);
+            Console.WriteLine($"Found {gitContributors.Count()} contributors");
+
             List<Commits> gitCommits = GitHubApi.Instance(rootPath).GetCommits(models, "");
+            Console.WriteLine($"Found {gitCommits.Count()} commits");
 
             if (gitContributors != null && gitCommits != null)
             {
@@ -40,10 +46,21 @@ namespace DNNCommunity.DNNDocs.Plugins
 
                         for (var i = 1; i < 6; i++)
                         {
-                            content["gitContributor" + i + "Contributions"] = gitContributors[i - 1].Contributions;
-                            content["gitContributor" + i + "Login"] = gitContributors[i - 1].Login;
-                            content["gitContributor" + i + "AvatarUrl"] = gitContributors[i - 1].AvatarUrl;
-                            content["gitContributor" + i + "HtmlUrl"] = gitContributors[i - 1].HtmlUrl;
+                            try
+                            {
+                                content["gitContributor" + i + "Contributions"] = gitContributors[i - 1].Contributions;
+                                content["gitContributor" + i + "Login"] = gitContributors[i - 1].Login;
+                                content["gitContributor" + i + "AvatarUrl"] = gitContributors[i - 1].AvatarUrl;
+                                content["gitContributor" + i + "HtmlUrl"] = gitContributors[i - 1].HtmlUrl;
+                            }
+                            catch (Exception)
+                            {
+                                // Ignore failures with an empty string
+                                content["gitContributor" + i + "Contributions"] = String.Empty;
+                                content["gitContributor" + i + "Login"] = String.Empty;
+                                content["gitContributor" + i + "AvatarUrl"] = String.Empty;
+                                content["gitContributor" + i + "HtmlUrl"] = String.Empty;
+                            }
                         }
 
                         var commits = gitCommits
@@ -55,10 +72,22 @@ namespace DNNCommunity.DNNDocs.Plugins
                         int index = 1;
                         foreach (var commit in commits)
                         {
-                            content["gitRecentContributor" + index + "Login"] = commit.Author.Login;
-                            content["gitRecentContributor" + index + "AvatarUrl"] = commit.Author.AvatarUrl;
-                            content["gitRecentContributor" + index + "HtmlUrl"] = commit.Author.HtmlUrl;
-                            index++;
+                            try
+                            {
+                                content["gitRecentContributor" + index + "Login"] = commit.Author.Login;
+                                content["gitRecentContributor" + index + "AvatarUrl"] = commit.Author.AvatarUrl;
+                                content["gitRecentContributor" + index + "HtmlUrl"] = commit.Author.HtmlUrl;
+                            }
+                            catch (Exception)
+                            {
+                                // Ignore failures with an empty string
+                                content["gitRecentContributor" + index + "Login"] = String.Empty;
+                                content["gitRecentContributor" + index + "AvatarUrl"] = String.Empty;
+                                content["gitRecentContributor" + index + "HtmlUrl"] = String.Empty;
+                            }
+                            finally{
+                                index++;
+                            }
                         }
                     }
                 }

--- a/plugins/DNNCommunity.DNNDocs.Plugins/RepoStatsBuildStep.cs
+++ b/plugins/DNNCommunity.DNNDocs.Plugins/RepoStatsBuildStep.cs
@@ -36,7 +36,7 @@ namespace DNNCommunity.DNNDocs.Plugins
             List<Commits> gitCommits = GitHubApi.Instance(rootPath).GetCommits(models, "");
             Console.WriteLine($"Found {gitCommits.Count()} commits");
 
-            if (gitContributors != null && gitCommits != null)
+            if (gitContributors.Any() && gitCommits.Any())
             {
                 foreach (var model in models)
                 {


### PR DESCRIPTION
This might help us pinpoint a deployment issue we are experiencing.

It both adds some defensive conding and adds some more logging so we can pinpoint the location where we are getting a null reference exception if it still happens.