### PR TITLE
Separate project `src` definitions for `docfx`

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -6,8 +6,6 @@
           "files": [
             "Dnn.Platform/DNN Platform/Library/DotNetNuke.Library.csproj",
             "Dnn.Platform/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Dnn.PersonaBar.Library.csproj",
-            "Dnn.Platform/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj",
-            "Dnn.Platform/DNN Platform/DotNetNuke.DependencyInjection/DotNetNuke.DependencyInjection.csproj",
             "Dnn.Platform/DNN Platform/DotNetNuke.Instrumentation/DotNetNuke.Instrumentation.csproj",
             "Dnn.Platform/DNN Platform/Providers/FolderProviders/DotNetNuke.Providers.FolderProviders.csproj",
             "Dnn.Platform/DNN Platform/Modules/DnnExportImport/DnnExportImport.csproj",
@@ -24,6 +22,29 @@
         }
       ],
       "dest": "api",
+      "properties": {
+        "TargetFramework": "net472"
+      },
+      "disableGitFeatures": false,
+      "disableDefaultFilter": false
+    },
+    {
+      "src": [
+        {
+          "files": [
+            "Dnn.Platform/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj",
+            "Dnn.Platform/DNN Platform/DotNetNuke.DependencyInjection/DotNetNuke.DependencyInjection.csproj"
+          ],
+          "exclude": [
+            "**/bin/**",
+            "**/obj/**"
+          ]
+        }
+      ],
+      "dest": "api",
+      "properties": {
+        "TargetFramework": "netstandard2.0"
+      },
       "disableGitFeatures": false,
       "disableDefaultFilter": false
     }


### PR DESCRIPTION
Since we have some DNN projects that are `net472` and some that are `netstandard2.0`, we are updating `docfx.json` accordingly to avoid build issues.