### PR TITLE
Update tutorials table of contents to correct typo

### DIFF
--- a/content/tutorials/toc.md
+++ b/content/tutorials/toc.md
@@ -234,7 +234,7 @@
 ##[Theme Objects](xref:theme-objects)
 ###[Breadcrumb](xref:breadcrumb)
 ###[CSSINCLUDE](xref:cssinclude)
-###[CSSEXINCLUDE](xref:cssexclude)
+###[CSSEXCLUDE](xref:cssexclude)
 ###[COPYRIGHT](xref:copyright)
 ###[CURRENTDATE](xref:currentdate)
 ###[DDRMenu](xref:ddrmenu-overview)


### PR DESCRIPTION
Update tutorials table of contents to correct typo.  This was missed during the review of #708 