### PR TITLE
Multiple updates and fixed missing Obsolete attributes

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -26,15 +26,15 @@ jobs:
     name: windows-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Cache .nuke/temp, ~/.nuget/packages
-        uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - name: 'Cache: .nuke/temp, ~/.nuget/packages'
+        uses: actions/cache@v4
         with:
           path: |
             .nuke/temp
             ~/.nuget/packages
-          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
-      - name: Run './build.cmd Deploy'
+          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
+      - name: 'Run: Deploy'
         run: ./build.cmd Deploy
         env:
           GithubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/PR_Validation.yml
+++ b/.github/workflows/PR_Validation.yml
@@ -26,15 +26,15 @@ jobs:
     name: windows-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Cache .nuke/temp, ~/.nuget/packages
-        uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - name: 'Cache: .nuke/temp, ~/.nuget/packages'
+        uses: actions/cache@v4
         with:
           path: |
             .nuke/temp
             ~/.nuget/packages
-          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
-      - name: Run './build.cmd Compile'
+          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
+      - name: 'Run: Compile'
         run: ./build.cmd Compile
         env:
           GithubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,51 +1,63 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
-  "$ref": "#/definitions/build",
   "definitions": {
-    "build": {
-      "type": "object",
+    "Host": {
+      "type": "string",
+      "enum": [
+        "AppVeyor",
+        "AzurePipelines",
+        "Bamboo",
+        "Bitbucket",
+        "Bitrise",
+        "GitHubActions",
+        "GitLab",
+        "Jenkins",
+        "Rider",
+        "SpaceAutomation",
+        "TeamCity",
+        "Terminal",
+        "TravisCI",
+        "VisualStudio",
+        "VSCode"
+      ]
+    },
+    "ExecutableTarget": {
+      "type": "string",
+      "enum": [
+        "Clean",
+        "Compile",
+        "CreateDeployBranch",
+        "CreateTokenFile",
+        "Deploy",
+        "PullDnnPackages",
+        "Restore",
+        "Serve",
+        "TemplateExportDefault"
+      ]
+    },
+    "Verbosity": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Verbose",
+        "Normal",
+        "Minimal",
+        "Quiet"
+      ]
+    },
+    "NukeBuild": {
       "properties": {
-        "Configuration": {
-          "type": "string",
-          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
-          "enum": [
-            "Debug",
-            "Release"
-          ]
-        },
         "Continue": {
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
-        },
-        "GithubToken": {
-          "type": "string",
-          "description": "Github Token"
         },
         "Help": {
           "type": "boolean",
           "description": "Shows the help text for this build assembly"
         },
         "Host": {
-          "type": "string",
           "description": "Host for execution. Default is 'automatic'",
-          "enum": [
-            "AppVeyor",
-            "AzurePipelines",
-            "Bamboo",
-            "Bitbucket",
-            "Bitrise",
-            "GitHubActions",
-            "GitLab",
-            "Jenkins",
-            "Rider",
-            "SpaceAutomation",
-            "TeamCity",
-            "Terminal",
-            "TravisCI",
-            "VisualStudio",
-            "VSCode"
-          ]
+          "$ref": "#/definitions/Host"
         },
         "NoLogo": {
           "type": "boolean",
@@ -74,55 +86,46 @@
           "type": "array",
           "description": "List of targets to be skipped. Empty list skips all dependencies",
           "items": {
-            "type": "string",
-            "enum": [
-              "BuildPlugins",
-              "Clean",
-              "Compile",
-              "CreateDeployBranch",
-              "CreateTokenFile",
-              "Deploy",
-              "PullDnnRepo",
-              "Restore",
-              "Serve",
-              "TemplateExportDefault"
-            ]
+            "$ref": "#/definitions/ExecutableTarget"
           }
-        },
-        "Solution": {
-          "type": "string",
-          "description": "Path to a solution file that is automatically loaded"
         },
         "Target": {
           "type": "array",
           "description": "List of targets to be invoked. Default is '{default_target}'",
           "items": {
-            "type": "string",
-            "enum": [
-              "BuildPlugins",
-              "Clean",
-              "Compile",
-              "CreateDeployBranch",
-              "CreateTokenFile",
-              "Deploy",
-              "PullDnnRepo",
-              "Restore",
-              "Serve",
-              "TemplateExportDefault"
-            ]
+            "$ref": "#/definitions/ExecutableTarget"
           }
         },
         "Verbosity": {
-          "type": "string",
           "description": "Logging verbosity during build execution. Default is 'Normal'",
-          "enum": [
-            "Minimal",
-            "Normal",
-            "Quiet",
-            "Verbose"
-          ]
+          "$ref": "#/definitions/Verbosity"
         }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "properties": {
+        "Configuration": {
+          "type": "string",
+          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
+        "GithubToken": {
+          "type": "string",
+          "description": "Github Token"
+        },
+        "Solution": {
+          "type": "string",
+          "description": "Path to a solution file that is automatically loaded"
+        }
+      }
+    },
+    {
+      "$ref": "#/definitions/NukeBuild"
+    }
+  ]
 }

--- a/build.ps1
+++ b/build.ps1
@@ -18,11 +18,10 @@ $TempDirectory = "$PSScriptRoot\\.nuke\temp"
 
 $DotNetGlobalFile = "$PSScriptRoot\\global.json"
 $DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
-$DotNetChannel = "Current"
+$DotNetChannel = "STS"
 
-$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
-$env:DOTNET_MULTILEVEL_LOOKUP = 0
+$env:DOTNET_NOLOGO = 1
 
 ###########################################################################
 # EXECUTION
@@ -61,9 +60,15 @@ else {
         ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Version $DotNetVersion -NoPath }
     }
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
+    $env:PATH = "$DotNetDirectory;$env:PATH"
 }
 
 Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
+
+if (Test-Path env:NUKE_ENTERPRISE_TOKEN) {
+    & $env:DOTNET_EXE nuget remove source "nuke-enterprise" > $null
+    & $env:DOTNET_EXE nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password $env:NUKE_ENTERPRISE_TOKEN > $null
+}
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -14,11 +14,10 @@ TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
 DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
-DOTNET_CHANNEL="Current"
+DOTNET_CHANNEL="STS"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-export DOTNET_MULTILEVEL_LOOKUP=0
+export DOTNET_NOLOGO=1
 
 ###########################################################################
 # EXECUTION
@@ -54,9 +53,15 @@ else
         "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "$DOTNET_VERSION" --no-path
     fi
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
+    export PATH="$DOTNET_DIRECTORY:$PATH"
 fi
 
 echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+
+if [[ ! -z ${NUKE_ENTERPRISE_TOKEN+x} && "$NUKE_ENTERPRISE_TOKEN" != "" ]]; then
+    "$DOTNET_EXE" nuget remove source "nuke-enterprise" &>/dev/null || true
+    "$DOTNET_EXE" nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password "$NUKE_ENTERPRISE_TOKEN" --store-password-in-clear-text &>/dev/null || true
+fi
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
@@ -12,11 +12,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.1.2" />
+    <PackageReference Include="Nuke.Common" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="docfx" Version="[2.60.2]" />
+    <PackageDownload Include="docfx" Version="[2.78.3]" />
+    <PackageDownload Include="NuGet.CommandLine" Version="[6.13.2]" />
   </ItemGroup>
 
 </Project>

--- a/docfx.json
+++ b/docfx.json
@@ -4,17 +4,16 @@
       "src": [
         {
           "files": [
-            "Dnn.Platform/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj",
-            "Dnn.Platform/DNN Platform/DotNetNuke.DependencyInjection/DotNetNuke.DependencyInjection.csproj",
-            "Dnn.Platform/DNN Platform/Library/DotNetNuke.Library.csproj",
-            "Dnn.Platform/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Dnn.PersonaBar.Library.csproj",
-            "Dnn.Platform/DNN Platform/DotNetNuke.Instrumentation/DotNetNuke.Instrumentation.csproj",
-            "Dnn.Platform/DNN Platform/Providers/FolderProviders/DotNetNuke.Providers.FolderProviders.csproj",
-            "Dnn.Platform/DNN Platform/Modules/DnnExportImport/DnnExportImport.csproj",
-            "Dnn.Platform/DNN Platform/Modules/DnnExportImportLibrary/DnnExportImportLibrary.csproj",
-            "Dnn.Platform/DNN Platform/DotNetNuke.Web.Client/DotNetNuke.Web.Client.csproj",
-            "Dnn.Platform/DNN Platform/DotNetNuke.Web.Mvc/DotNetNuke.Web.Mvc.csproj",
-            "Dnn.Platform/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj"
+            "packages/DotNetNuke.Core*/**/DotNetNuke.dll",
+            "packages/DotNetNuke.Abstractions*/**/DotNetNuke.Abstractions.dll",
+            "packages/DotNetNuke.DependencyInjection*/**/DotNetNuke.DependencyInjection.dll",
+            "packages/Dnn.PersonaBar.Library*/**/Dnn.PersonaBar.Library.dll",
+            "packages/DotNetNuke.Instrumentation*/**/DotNetNuke.Instrumentation.dll",
+            "packages/DotNetNuke.Providers.FolderProviders*/**/DotNetNuke.Providers.FolderProviders.dll",
+            "packages/DotNetNuke.SiteExportImport*/**/DotNetNuke.SiteExportImport.dll",
+            "packages/DotNetNuke.Web*/**/DotNetNuke.Web.dll",
+            "packages/DotNetNuke.Web*/**/DotNetNuke.Web.Client.dll",
+            "packages/DotNetNuke.Web*/**/DotNetNuke.Web.Mvc.dll"
           ],
           "exclude": [
             "**/bin/**",
@@ -25,7 +24,7 @@
       ],
       "dest": "api",
       "disableGitFeatures": false,
-      "disableDefaultFilter": false
+      "disableDefaultFilter": false,
     }
   ],
   "build": {
@@ -62,11 +61,11 @@
     "globalMetadataFiles": [],
     "fileMetadataFiles": [],
     "template": ["default", "templates/dnn-docs"],
-    "postProcessors": ["RepoStatsProcessor","PageStatsProcessor","MoreLinksProcessor"],
+    //"postProcessors": ["RepoStatsProcessor","PageStatsProcessor","MoreLinksProcessor"],
     "markdownEngineName": "markdig",
     "noLangKeyword": false,
     "keepFileLink": false,
     "cleanupCacheHistory": false,
-    "disableGitFeatures": false 
+    "disableGitFeatures": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.302",
+    "version": "9.0.201",
     "rollForward": "latestMajor"
   }
 }

--- a/templates/dnn-docs/partials/scripts.tmpl.partial
+++ b/templates/dnn-docs/partials/scripts.tmpl.partial
@@ -1,5 +1,8 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.3.1/anchor.min.js"></script>
 <script type="text/javascript" src="{{_rel}}styles/docfx.vendor.js"></script>
 <script type="text/javascript" src="{{_rel}}styles/docfx.js"></script>
 <script type="text/javascript" src="{{_rel}}styles/main.js"></script>
@@ -17,3 +20,5 @@
 	};	
 	docsearch(document.dnndocs.algolia('#docsearch-navbar'));  
 </script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
+


### PR DESCRIPTION
Soooo, what happened was...

I was going to take a look at #742 but then could no longer build locally due to lack of dotnet6. I decided to update Nuke to latest (dotnet9) and it fixed the build but then I had other issues and upgraded docfx to fix those.

Now I could troubleshoot #742 but noticed out template did not work right with the docfx updates because the new base template no longer loads some libraries out-of-the-box like jquery and other plugins. So I added those scripts to bypass that breaking change.

Then our custom plugins (which were already not working) stopped compiling, so I commented that out for now to revisit, it looks like the nuget packages to reference have changed and I can probably tackle rebuilding them in my next PR.

Then I tried a lot of stuff to try and figure out the missing Obsolete documentation. What ended up working was to reference our nuget packages instead of our source code. This may actually solve 2 issues as we have both sourcelink and portable symbols.

Soooo long story short, fixes #742 and a couple more things.