### PR TITLE
Updates string arguments in build

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -205,7 +205,7 @@ class Build : NukeBuild
             Git("status");
             Git("add docs -f"); // Force adding because it is usually gitignored.
             Git("status");
-            Git("commit --allow-empty -m \"Commit latest build\""); // We allow an empty commit in case the last change did not affect the site.
+            Git("commit --allow-empty -m", "Commit latest build"); // We allow an empty commit in case the last change did not affect the site.
             Git("status");
             Git("fetch origin");
             Git("status");
@@ -220,7 +220,7 @@ class Build : NukeBuild
 
             Git("add docs"); // stage the docs
             Git("status");
-            Git("commit --allow-empty -m \"Commit latest build\"");
+            Git("commit --allow-empty -m", "Commit latest build");
             Git("status");
             Git("push origin site"); // Should push only the change with linear history and a proper diff.
             Git("checkout deploy");


### PR DESCRIPTION
Nuke has changed how quotes are automatically added to process arguments and some commands were not working in latest build upgrade.

This should fix it, I'll merge directly as this can't be tested without merging.