### PR TITLE
Commit latest build schema file

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -31,8 +31,7 @@
         "Deploy",
         "PullDnnPackages",
         "Restore",
-        "Serve",
-        "TemplateExportDefault"
+        "Serve"
       ]
     },
     "Verbosity": {


### PR DESCRIPTION
Nuke creates a build.schema.json file that contains metadata about cli options. Due to merging diffrent PRs that touched build.cs, this file no longer matched the current state and needs to be commited to fix CI.