### PR TITLE
Changed font paths

### DIFF
--- a/templates/dnn-docs/styles/docfx.vendor.css
+++ b/templates/dnn-docs/styles/docfx.vendor.css
@@ -62,7 +62,15 @@ h2,h3{page-break-after:avoid}
 .dropdown-menu,.modal-content{-webkit-background-clip:padding-box}
 .btn,.btn-danger.active,.btn-danger:active,.btn-default.active,.btn-default:active,.btn-info.active,.btn-info:active,.btn-primary.active,.btn-primary:active,.btn-warning.active,.btn-warning:active,.btn.active,.btn:active,.dropdown-menu>.disabled>a:focus,.dropdown-menu>.disabled>a:hover,.form-control,.navbar-toggle,.open>.dropdown-toggle.btn-danger,.open>.dropdown-toggle.btn-default,.open>.dropdown-toggle.btn-info,.open>.dropdown-toggle.btn-primary,.open>.dropdown-toggle.btn-warning{background-image:none}
 .img-thumbnail,body{background-color:#fff}
-@font-face{font-family:'Glyphicons Halflings';src:url(../fonts/glyphicons-halflings-regular.eot);src:url(../fonts/glyphicons-halflings-regular.eot?#iefix) format('embedded-opentype'),url(../fonts/glyphicons-halflings-regular.woff2) format('woff2'),url(../fonts/glyphicons-halflings-regular.woff) format('woff'),url(../fonts/glyphicons-halflings-regular.ttf) format('truetype'),url(../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular) format('svg')}
+@font-face{
+    font-family:'Glyphicons Halflings';
+    src:url(glyphicons-halflings-regular.eot);
+    src:url(glyphicons-halflings-regular.eot?#iefix) format('embedded-opentype'),
+        url(glyphicons-halflings-regular.woff2) format('woff2'),
+        url(glyphicons-halflings-regular.woff) format('woff'),
+        url(glyphicons-halflings-regular.ttf) format('truetype'),
+        url(glyphicons-halflings-regular.svg#glyphicons_halflingsregular) format('svg')
+}
 .glyphicon{position:relative;top:1px;display:inline-block;font-family:'Glyphicons Halflings';font-weight:400;line-height:1;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
 .glyphicon-asterisk:before{content:"\002a"}
 .glyphicon-plus:before{content:"\002b"}


### PR DESCRIPTION
In newer versions of docfx the fonts are no longer in a fonts folder but right next to the css files.