### PR TITLE
Resurface Top Contributors and Recent Contributors

### DIFF
--- a/templates/dnn-docs/index.html.tmpl
+++ b/templates/dnn-docs/index.html.tmpl
@@ -184,20 +184,18 @@
           {{^_disableAffix}}
           <div class="hidden-sm col-md-2" role="complementary">
             <div class="home side-content">
-                {{>partials/sidebar/communityEvents}}
-            </div>
-            <div class="home side-content">
-                {{>partials/sidebar/helpfulLinks}}
-            </div>
-<!--
-						<div class="home side-content">
                 {{>partials/sidebar/topContributors}}
             </div>
             <div class="home side-content">
                 {{>partials/sidebar/recentContributors}}
             </div>
--->
-					</div>
+            <div class="home side-content">
+                {{>partials/sidebar/communityEvents}}
+            </div>
+            <div class="home side-content">
+                {{>partials/sidebar/helpfulLinks}}
+            </div>
+          </div>
           {{/_disableAffix}}
         </div>
       </div>


### PR DESCRIPTION
Now that the stats are working again, it is safe to resurface these sections on the home page of DNN Docs.

![image](https://github.com/user-attachments/assets/65c6d41c-3fe4-4476-9c2b-0a1c2fb4953e)

Resolves #692 
