### PR TITLE
Fixed selection of top/recent contributors

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -122,6 +122,11 @@ class Build : NukeBuild
         .DependsOn(PullDnnPackages)
         .Executes(() =>
         {
+            if (!InvokedTargets.Contains(Deploy))
+            {
+                Environment.SetEnvironmentVariable("SKIP_CONTRIBUTORS", "true");
+            }
+
             DnnDocFX?.Invoke("metadata", RootDirectory);
             DnnDocFX?.Invoke("build", RootDirectory);
         });

--- a/plugins/DNNCommunity.DNNDocs.Plugins/Providers/GitHubApi.cs
+++ b/plugins/DNNCommunity.DNNDocs.Plugins/Providers/GitHubApi.cs
@@ -17,7 +17,12 @@ namespace DNNCommunity.DNNDocs.Plugins.Providers
             client = new GitHubClient(new ProductHeaderValue("DNNDocsPlugin"));
            
             // Optionally pull from env if not passed
-            this.token = Environment.GetEnvironmentVariable("GithubToken") ?? string.Empty;
+            var skip = Environment.GetEnvironmentVariable("SKIP_CONTRIBUTORS") == "true";
+            if (!skip)
+            {
+                this.token = Environment.GetEnvironmentVariable("GithubToken") ?? string.Empty;
+            }
+
             if (!string.IsNullOrEmpty(this.token))
             {
                 client.Credentials = new Credentials(this.token);


### PR DESCRIPTION
This fixed the selection of top vs recent contributors, also only 4 were shown for recent which is not fixed to show 5.

Also it avoids running the contributors REST API calls when the CI build is for PR validation and not for a deployment